### PR TITLE
Migrate frontend from Create React App to Vite (toolchain + env updates)

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,2 @@
-PORT=8080
-REACT_APP_SERVER_HOSTNAME=http://localhost:3000
-#REACT_APP_SERVER_HOSTNAME=https://image-game-server.adaptable.app
+VITE_SERVER_HOSTNAME=http://localhost:3000
+#VITE_SERVER_HOSTNAME=https://image-game-server.adaptable.app

--- a/README.md
+++ b/README.md
@@ -1,70 +1,32 @@
-# Getting Started with Create React App
+# Image Game Client
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+This project now uses a Vite-based React toolchain (migrated from Create React App) to avoid the stale `react-scripts` dependency tree.
 
 ## Available Scripts
 
-In the project directory, you can run:
+In the project directory, run:
 
 ### `npm start`
-
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
-
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
-
-### `npm test`
-
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+Starts the Vite development server on `http://localhost:3000`.
 
 ### `npm run build`
+Builds the production bundle to `dist/`.
 
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
+### `npm run preview`
+Serves the production build locally for verification.
 
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
+### `npm test`
+Runs the Vitest test suite once in `jsdom`.
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+### `npm run test:watch`
+Runs Vitest in watch mode.
 
-### `npm run eject`
+## Environment Variables
 
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
+Use Vite-style environment variables:
 
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+- `VITE_SERVER_HOSTNAME` – backend socket host (defaults to `http://<current-hostname>:3000`).
 
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
+## Why this migration
 
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
-
-### Analyzing the Bundle Size
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
-
-### Making a Progressive Web App
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
-
-### Advanced Configuration
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
-
-### Deployment
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
-
-### `npm run build` fails to minify
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+The CRA `react-scripts@5.x` stack pins transitive packages like `@svgr/plugin-svgo@5` / `svgo@1`, which are frequent security-advisory hotspots. Migrating to a maintained toolchain is the structural remediation path.

--- a/SECURITY_REMEDIATION_ROUTINES.md
+++ b/SECURITY_REMEDIATION_ROUTINES.md
@@ -1,0 +1,131 @@
+# Security advisory remediation routines
+
+This repository currently depends on `react-scripts@5.0.1` and inherits a number of older transitive packages. In this execution environment I could not query GitHub Dependabot alerts or the npm audit API directly (both returned HTTP 403), so the routines below are based on the dependency graph in `package-lock.json` and known advisory hotspots commonly flagged for this stack.
+
+## How to use this document with Dependabot
+
+For each alert in GitHub:
+1. Match the alert package name to the section below.
+2. Apply the **Immediate routine** first (lowest-risk patch path).
+3. If Dependabot still cannot resolve cleanly, apply the **Structural routine** for that package family.
+
+---
+
+## 1) `nth-check@1.0.2` via `svgo@1.3.2`
+
+**Observed path**
+`react-scripts -> @svgr/webpack -> @svgr/plugin-svgo -> svgo@1.3.2 -> css-select@2.1.0 -> nth-check@1.0.2`
+
+**Risk pattern**
+Old `nth-check` versions are frequently flagged for ReDoS.
+
+**Immediate routine**
+- Add an npm `overrides` entry for `nth-check` forcing `^2.1.1`.
+- Regenerate lockfile and run build/tests.
+- Verify generated SVG handling still works.
+
+**Structural routine**
+- Replace `react-scripts` with a maintained toolchain (Vite/Next/custom webpack) so `@svgr/plugin-svgo@5`/`svgo@1` are no longer pinned.
+
+---
+
+## 2) `postcss@8.4.27` (and `postcss@7.0.39`)
+
+**Observed paths**
+Multiple `react-scripts` CSS plugins pin `postcss@8.4.27`; `resolve-url-loader` pulls `postcss@7.0.39`.
+
+**Risk pattern**
+Dependabot often flags older PostCSS lines for parser bypass/ReDoS-class issues.
+
+**Immediate routine**
+- Add `overrides` for `postcss` to a patched version in the 8.4.x line where compatible.
+- Validate CSS build output and source maps (`resolve-url-loader` path is sensitive).
+
+**Structural routine**
+- Remove `react-scripts` dependency chain and move to newer bundler plugins that do not drag PostCSS 7.
+
+---
+
+## 3) `webpack-dev-server@4.15.1` + `http-proxy-middleware@2.0.9`
+
+**Observed path**
+`react-scripts -> webpack-dev-server@4.15.1 -> http-proxy-middleware@2.0.9`
+
+**Risk pattern**
+Dev-server/proxy packages frequently receive advisories around request smuggling, origin checks, and denial-of-service conditions.
+
+**Immediate routine**
+- Use `overrides` to bump `http-proxy-middleware` and `webpack-dev-server` to patched minors/patches compatible with webpack 5.
+- Re-test local dev workflow (HMR, proxy routes, websocket reconnects).
+
+**Structural routine**
+- Migrate off CRA dev server (`react-scripts start`) to Vite or another modern server with active maintenance.
+
+---
+
+## 4) `ws` versions (`7.5.10`, `8.17.1`, `8.18.3`)
+
+**Observed paths**
+- `react-scripts -> jest/jsdom -> ws@7.5.10`
+- `socket.io-client -> engine.io-client -> ws@8.17.1`
+- `webpack-dev-server -> ws@8.18.3`
+
+**Risk pattern**
+`ws` has had multiple DoS and header-validation advisories across major lines.
+
+**Immediate routine**
+- Add `overrides` to patched `ws` versions per major line where consumers allow it.
+- Prefer updating parents (`socket.io-client`, `engine.io-client`, `jest/jsdom`) before forcing overrides.
+
+**Structural routine**
+- Upgrade test/runtime stacks so old major lines (`ws@7`) are eliminated.
+
+---
+
+## 5) `serialize-javascript@4.0.0`
+
+**Observed path**
+`react-scripts -> workbox-webpack-plugin -> workbox-build -> rollup-plugin-terser -> serialize-javascript@4.0.0`
+
+**Risk pattern**
+Older `serialize-javascript` versions are commonly flagged for XSS-related unsafe serialization cases.
+
+**Immediate routine**
+- Add `overrides` for `serialize-javascript` to `^6.0.2` where semver allows.
+- Confirm service worker build (`workbox`) still compiles.
+
+**Structural routine**
+- Upgrade or replace workbox build chain through toolchain migration.
+
+---
+
+## 6) `svgo@1.3.2`
+
+**Observed path**
+`react-scripts -> @svgr/plugin-svgo@5.5.0 -> svgo@1.3.2`
+
+**Risk pattern**
+`svgo` v1 is deprecated and appears in many advisory chains through sub-dependencies.
+
+**Immediate routine**
+- Attempt targeted override only if compatible; expect breakage risk because v1->v2 is major.
+
+**Structural routine (recommended)**
+- Move to a build stack that uses modern `@svgr/*` and `svgo@2+`.
+
+---
+
+## Practical execution order (lowest disruption first)
+
+1. Create a dedicated `security/dependabot-remediation` branch.
+2. Apply **override-only** lockfile remediations for leaf deps first (`nth-check`, `postcss`, `serialize-javascript`, `ws`).
+3. Run checks: `npm run build` + test suite.
+4. If alerts remain blocked by pinned transitive deps in CRA, plan toolchain migration as the durable fix.
+
+## Suggested PR slicing strategy
+
+- **PR A (Low risk):** overrides + lockfile refresh for leaf vulnerabilities.
+- **PR B (Medium risk):** direct dep bumps (`socket.io-client`, test libs).
+- **PR C (High value):** migrate from CRA/`react-scripts` to maintained build system.
+
+This sequencing keeps production risk low while making steady progress through Dependabot alerts one-by-one.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="description" content="Image game client" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" href="/logo192.png" />
+    <title>Image Game Client</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -3,39 +3,27 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^14.0.0",
-    "@testing-library/user-event": "^14.4.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.30.3",
-    "react-scripts": "5.0.1",
     "socket.io-client": "4.7.1",
     "uuid": "^9.0.0",
     "web-vitals": "^3.4.0"
   },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
+    "@vitejs/plugin-react": "^4.3.4",
+    "jsdom": "^24.1.3",
+    "vite": "^5.4.14",
+    "vitest": "^2.1.8"
+  },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
-  },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
+    "start": "vite",
+    "build": "vite build",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "preview": "vite preview"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,7 @@ function App() {
   
   useEffect(() => {
     
-    const location = process.env.REACT_APP_SERVER_HOSTNAME || `http://${window.location.hostname}:3000`
+    const location = import.meta.env.VITE_SERVER_HOSTNAME || `http://${window.location.hostname}:3000`
 
     console.log(`Locations ${location}`);
     const newSocket = io(location);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: true,
+    port: 3000
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.js',
+    globals: true
+  }
+});


### PR DESCRIPTION
### Motivation
- Remove the unmaintained `react-scripts` toolchain and its pinned transitive dependencies to reduce security advisory exposure and enable a maintained build/test stack.
- Standardize environment variables for Vite by moving to `VITE_*` names so runtime configuration works with the new toolchain.

### Description
- Replaced CRA wiring with Vite by removing `react-scripts` and adding `vite`, `@vitejs/plugin-react`, and `vitest`, and updated `package.json` `scripts` to `start`, `build`, `preview`, `test`, and `test:watch` that invoke Vite/Vitest via `vite` and `vitest` commands.
- Updated runtime env usage in `src/App.js` from `process.env.REACT_APP_SERVER_HOSTNAME` to `import.meta.env.VITE_SERVER_HOSTNAME` and renamed `.env` entries to `VITE_SERVER_HOSTNAME`.
- Added `vite.config.js` and a Vite-compatible `index.html`, moved testing/dev-only libraries into `devDependencies`, and removed CRA-specific files and configs.
- Added `SECURITY_REMEDIATION_ROUTINES.md` documenting recommended remediation steps (overrides and migration strategy) and updated `README.md` to reflect the Vite-based workflow and environment variable usage.

### Testing
- No automated tests were executed as part of this rollout; the change includes test runner configuration for Vitest (`test`/`test:watch`) and the repository should run `npm run build` and `npm test` in CI to validate the migration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a454c9d104832d847e9bcfea712476)